### PR TITLE
Potential fix for code scanning alert no. 5: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/internal/helper/StringGeneration.go
+++ b/internal/helper/StringGeneration.go
@@ -22,7 +22,11 @@ func generateUnsafeId(length int) string {
 	log.Println("Warning! Cannot generate securely random ID!")
 	b := make([]rune, length)
 	for i := range b {
-		b[i] = characters[rand.Intn(len(characters))]
+		idx, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(len(characters))))
+		if err != nil {
+			panic("Failed to generate random index")
+		}
+		b[i] = characters[idx.Int64()]
 	}
 	return string(b)
 }
@@ -43,7 +47,7 @@ func generateRandomBytes(n int) ([]byte, error) {
 func GenerateRandomString(length int) string {
 	b, err := generateRandomBytes(length + 10)
 	if err != nil {
-		return generateUnsafeId(length)
+		panic("Failed to generate secure random string")
 	}
 	result := cleanRandomString(base64.URLEncoding.EncodeToString(b))
 	if len(result) < length {


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/Gokapi/security/code-scanning/5](https://github.com/codeallthethingsbreak/Gokapi/security/code-scanning/5)

To address the issue, replace the use of `math/rand` with `crypto/rand` for generating random values in security-sensitive contexts. Specifically:
1. Modify the `generateUnsafeId` function in `internal/helper/StringGeneration.go` to use `crypto/rand` instead of `math/rand`.
2. Ensure that `GenerateRandomString` no longer relies on `generateUnsafeId` as a fallback.
3. Update all instances where `GenerateRandomString` is used to ensure secure random values are generated.

Changes required:
- Replace `rand.Intn` with `crypto/rand.Int` in `generateUnsafeId`.
- Remove the fallback to `generateUnsafeId` in `GenerateRandomString`.
- Add error handling for secure random generation failures.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
